### PR TITLE
refactor: use the `std::vector` and `std::array` for the constructor  of `Predcited**`

### DIFF
--- a/include/mtr/mtr.hpp
+++ b/include/mtr/mtr.hpp
@@ -154,8 +154,9 @@ private:
 
   IntentionPoint intention_point_;
 
-  size_t num_target_, num_agent_, num_timestamp_, num_agent_dim_, num_agent_class_, num_agent_attr_;
-  size_t num_polyline_, num_point_, num_point_dim_, num_point_attr_;
+  int32_t num_target_, num_agent_, num_timestamp_, num_agent_dim_, num_agent_class_,
+    num_agent_attr_;
+  int32_t num_polyline_, num_point_, num_point_dim_, num_point_attr_;
 
   // source data
   cuda::unique_ptr<int[]> d_target_index_{nullptr};
@@ -181,8 +182,8 @@ private:
   // outputs
   cuda::unique_ptr<float[]> d_out_score_{nullptr};
   cuda::unique_ptr<float[]> d_out_trajectory_{nullptr};
-  std::unique_ptr<float[]> h_out_score_{nullptr};
-  std::unique_ptr<float[]> h_out_trajectory_{nullptr};
+  std::vector<float> h_out_score_;
+  std::vector<float> h_out_trajectory_;
 
   // debug
   cuda::EventDebugger event_debugger_;

--- a/include/mtr/trajectory.hpp
+++ b/include/mtr/trajectory.hpp
@@ -29,14 +29,14 @@ constexpr size_t PredictedStateDim = 7;
  */
 struct PredictedState
 {
-  explicit PredictedState(const float * state)
-  : x_(state[0]),
-    y_(state[1]),
-    dx_(state[2]),
-    dy_(state[3]),
-    yaw_(state[4]),
-    vx_(state[5]),
-    vy_(state[6])
+  explicit PredictedState(const std::array<float, PredictedStateDim> & state)
+  : x_(state.at(0)),
+    y_(state.at(1)),
+    dx_(state.at(2)),
+    dy_(state.at(3)),
+    yaw_(state.at(4)),
+    vx_(state.at(5)),
+    vy_(state.at(6))
   {
   }
 
@@ -62,17 +62,18 @@ private:
 };  // struct PredictedState
 
 /**
- * @brief A class to represent waypoints for a single mode.
+ * @brief A class to represent waypoints for a single motion mode.
  */
 struct PredictedMode
 {
-  PredictedMode(const float score, const float * waypoints, const size_t num_future)
+  PredictedMode(const float score, const std::vector<float> & waypoints, const size_t num_future)
   : score_(score), num_future_(num_future)
   {
     for (size_t t = 0; t < num_future_; ++t) {
-      const auto start_ptr = waypoints + t * num_state_dim_;
-      std::vector<float> state(start_ptr, start_ptr + num_state_dim_);
-      waypoints_.emplace_back(state.data());
+      const auto start_itr = waypoints.cbegin() + t * num_state_dim_;
+      std::array<float, PredictedStateDim> state;
+      std::copy_n(start_itr, PredictedStateDim, state.begin());
+      waypoints_.emplace_back(state);
     }
   }
 
@@ -98,15 +99,15 @@ private:
 struct PredictedTrajectory
 {
   PredictedTrajectory(
-    const float * scores, const float * trajectories, const size_t num_mode,
+    const std::vector<float> & scores, const std::vector<float> & modes, const size_t num_mode,
     const size_t num_future)
   : num_mode_(num_mode), num_future_(num_future)
   {
     for (size_t m = 0; m < num_mode_; ++m) {
-      const auto score = *(scores + m);
-      const auto start_ptr = trajectories + m * num_future_ * num_state_dim_;
-      std::vector<float> waypoints(start_ptr, start_ptr + num_future_ * num_state_dim_);
-      modes_.emplace_back(score, waypoints.data(), num_future_);
+      const auto score = scores.at(m);
+      const auto wp_itr = modes.cbegin() + m * num_future_ * num_state_dim_;
+      std::vector<float> waypoints(wp_itr, wp_itr + num_future_ * num_state_dim_);
+      modes_.emplace_back(score, waypoints, num_future_);
     }
 
     // sort by score


### PR DESCRIPTION
## What

Refactoring `Predicted**` with following features:
- Use the `std::vector` or `std::array` in the constructors instead of `*ptr`
- Declare predicted score and trajectory on the host device with `std::vector`