### PR TITLE
perf:update preprocess

### DIFF
--- a/include/mtr/cuda_helper.hpp
+++ b/include/mtr/cuda_helper.hpp
@@ -157,7 +157,7 @@ class StreamRingBuffer
     return res;
   }
 
-  void SyncAllStreams(void)
+  void syncAllStreams(void)
   {
     for (const auto& s : ring_buffer_) {
       CHECK_CUDA_ERROR(cudaStreamSynchronize(s));

--- a/include/mtr/mtr.hpp
+++ b/include/mtr/mtr.hpp
@@ -151,6 +151,7 @@ private:
 
   std::unique_ptr<MTRBuilder> builder_;
   cudaStream_t stream_{nullptr};
+  cuda::StreamRingBuffer copy_streams_;
 
   IntentionPoint intention_point_;
 

--- a/lib/src/preprocess/polyline_preprocess_kernel.cu
+++ b/lib/src/preprocess/polyline_preprocess_kernel.cu
@@ -244,7 +244,7 @@ cudaError_t polylinePreprocessWithTopkLauncher(
               << threadsPerBlock * itemsPerThread << ") detected." << std::endl;
     return cudaError_t::cudaErrorInvalidValue;
   }
-  extractTopKPolylineKernel<threadsPerBlock, itemsPerThread><<<blocks3, threadsPerBlock>>>(
+  extractTopKPolylineKernel<threadsPerBlock, itemsPerThread><<<blocks3, threadsPerBlock, 0, stream>>>(
     K, B, L, P, outPointDim, tmpPolyline, tmpPolylineMask, tmpDistance, outPolyline,
     outPolylineMask);
 

--- a/lib/src/preprocess/polyline_preprocess_kernel.cu
+++ b/lib/src/preprocess/polyline_preprocess_kernel.cu
@@ -18,6 +18,41 @@
 #include <float.h>
 
 #include <iostream>
+#include <cub/cub.cuh>
+
+namespace
+{
+/**
+ * @struct index_and_value_t
+ * Utility struct to pass array index and value to CUB API at the same time
+ */
+struct index_and_value_t
+{
+  unsigned int idx;
+  float value;
+
+  index_and_value_t() = default;
+  __device__ index_and_value_t(unsigned int i, float val)
+      : idx(i)
+      , value(val)
+  {}
+};
+
+static __device__ bool operator==(const index_and_value_t& lhs, const index_and_value_t& rhs)
+{
+  return lhs.value == rhs.value;
+}
+
+struct decomposer_t
+{
+  __device__ ::cuda::std::tuple<float&> operator()(index_and_value_t& key) const
+  {
+    // The leftmost element of the tuple is considered the most significant
+    // Only `value` member will be returned because it only the member to be used for sort
+    return {key.value};
+  }
+};
+}
 
 __global__ void transformPolylineKernel(
   const int K, const int P, const int PointDim, const float * inPolyline, const int B,
@@ -127,51 +162,53 @@ __global__ void calculateCenterDistanceKernel(
   distance[b * K + k] = hypot(centerX, centerY);
 }
 
+template <unsigned int BLOCK_THREADS, unsigned int ITEMS_PER_THREAD>
 __global__ void extractTopKPolylineKernel(
   const int K, const int B, const int L, const int P, const int D, const float * inPolyline,
   const bool * inPolylineMask, const float * inDistance, float * outPolyline,
   bool * outPolylineMask)
 {
   int b = blockIdx.x;                             // Batch index
-  int tid = threadIdx.x;                          // Polyline index
+  int tid = threadIdx.x;                          // Thread local index in this CUDA block
   int p = blockIdx.y * blockDim.y + threadIdx.y;  // Point index
   int d = blockIdx.z * blockDim.z + threadIdx.z;  // Dim index
+  // Since all threads in a block expected to work wiht CUB, `return` shold not be called here
+  // if (b >= B || tid >= L || p >= P || d >= D) {
+  //   return;
+  // }
+
+  // Specialize BlockRadixSort type
+  using BlockRadixSortT = cub::BlockRadixSort<index_and_value_t, BLOCK_THREADS, ITEMS_PER_THREAD>;
+  using TempStorageT = typename BlockRadixSortT::TempStorage;
+
+  __shared__ TempStorageT temp_storage;
+
+  index_and_value_t distances[ITEMS_PER_THREAD];
+  for (unsigned int i = 0; i < ITEMS_PER_THREAD; i++) {
+    int polyline_idx = BLOCK_THREADS * i + tid; // index order don't need to care.
+    int distance_idx = b * L + polyline_idx;
+    distances[i].idx = polyline_idx;
+    distances[i].value = (polyline_idx < L && distance_idx < B * L)
+                         ? inDistance[distance_idx] : FLT_MAX;
+  }
+
+  BlockRadixSortT(temp_storage).Sort(distances, decomposer_t{});
+  // Block-wide sync barrier necessary to refer the sort result
+  __syncthreads();
+
   if (b >= B || tid >= L || p >= P || d >= D) {
     return;
   }
-  extern __shared__ float distances[];
 
-  // Load distances into shared memory
-  if (tid < L) {
-    distances[tid] = inDistance[b * L + tid];
-  }
-  __syncthreads();
-
-  // Simple selection of the smallest K distances
-  // (this part should be replaced with a more efficient sorting/selecting algorithm)
-  for (int k = 0; k < K; k++) {
-    float minDistance = FLT_MAX;
-    int minIndex = -1;
-
-    for (int l = 0; l < L; l++) {
-      if (distances[l] < minDistance) {
-        minDistance = distances[l];
-        minIndex = l;
-      }
-    }
-    __syncthreads();
-
-    if (minIndex == -1) {
+  for (unsigned int i = 0;  i < ITEMS_PER_THREAD; i++) {
+    int consective_polyline_idx = tid * ITEMS_PER_THREAD + i;  // To keep sorted order, theads have to write consective region
+    int inIdx = b * L * P + distances[i].idx * P + p;
+    int outIdx = b * K * P + consective_polyline_idx * P + p;
+    if (consective_polyline_idx >= K || fabsf(FLT_MAX - distances[i].value) < FLT_EPSILON) {
       continue;
     }
-
-    if (tid == k) {  // this thread will handle copying the k-th smallest polyline
-      int inIdx = b * L * P + minIndex * P + p;
-      int outIdx = b * K * P + k * P + p;
-      outPolyline[outIdx * D + d] = inPolyline[inIdx * D + d];
-      outPolylineMask[outIdx] = inPolylineMask[inIdx];
-    }
-    distances[minIndex] = FLT_MAX;  // exclude this index from future consideration
+    outPolyline[outIdx * D + d] = inPolyline[inIdx * D + d];
+    outPolylineMask[outIdx] = inPolylineMask[inIdx];
   }
 }
 
@@ -234,8 +271,13 @@ cudaError_t polylinePreprocessWithTopkLauncher(
     B, L, P, outPointDim, tmpPolyline, tmpPolylineMask, tmpDistance);
 
   const dim3 blocks3(B, P, outPointDim);
-  const size_t sharedMemSize = sizeof(float) * L;
-  extractTopKPolylineKernel<<<blocks3, threadsPerBlock, sharedMemSize, stream>>>(
+  constexpr unsigned int itemsPerThread = 24;
+  if (threadsPerBlock * itemsPerThread < L) {
+    std::cerr << "Larger L (" << L << ") than acceptable range (< "
+              << threadsPerBlock * itemsPerThread << ") detected." << std::endl;
+    return cudaError_t::cudaErrorInvalidValue;
+  }
+  extractTopKPolylineKernel<threadsPerBlock, itemsPerThread><<<blocks3, threadsPerBlock>>>(
     K, B, L, P, outPointDim, tmpPolyline, tmpPolylineMask, tmpDistance, outPolyline,
     outPolylineMask);
 

--- a/src/mtr.cpp
+++ b/src/mtr.cpp
@@ -24,7 +24,8 @@ TrtMTR::TrtMTR(
   const std::string & model_path, const MTRConfig & config, const BuildConfig & build_config,
   const size_t max_workspace_size)
 : config_(config),
-  intention_point_(config_.intention_point_filepath, config_.num_intention_point_cluster)
+  intention_point_(config_.intention_point_filepath, config_.num_intention_point_cluster),
+  copy_streams_(7)  // 7 is the maximum number of consecutive memory copy in this class
 {
   builder_ = std::make_unique<MTRBuilder>(model_path, build_config, max_workspace_size);
   builder_->setup();
@@ -143,30 +144,33 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
 {
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_target_index_.get(), agent_data.target_indices().data(), sizeof(int) * num_target_,
-    cudaMemcpyHostToDevice, stream_));
+    cudaMemcpyHostToDevice, copy_streams_()));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_label_index_.get(), agent_data.label_indices().data(), sizeof(int) * num_agent_,
-    cudaMemcpyHostToDevice, stream_));
+    cudaMemcpyHostToDevice, copy_streams_()));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_timestamps_.get(), agent_data.timestamps().data(), sizeof(float) * num_timestamp_,
-    cudaMemcpyHostToDevice, stream_));
+    cudaMemcpyHostToDevice, copy_streams_()));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_trajectory_.get(), agent_data.data_ptr(), sizeof(float) * agent_data.size(),
-    cudaMemcpyHostToDevice, stream_));
+    cudaMemcpyHostToDevice, copy_streams_()));
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_target_state_.get(), agent_data.target_data_ptr(),
-    sizeof(float) * num_target_ * num_agent_dim_, cudaMemcpyHostToDevice, stream_));
+    sizeof(float) * num_target_ * num_agent_dim_, cudaMemcpyHostToDevice, copy_streams_()));
 
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_polyline_.get(), polyline_data.data_ptr(), sizeof(float) * polyline_data.size(),
-    cudaMemcpyHostToDevice, stream_));
+    cudaMemcpyHostToDevice, copy_streams_()));
 
   const auto target_label_names = getLabelNames(agent_data.target_label_indices());
   const auto intention_points = intention_point_.get_points(target_label_names);
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     d_intention_points_.get(), intention_points.data(),
     sizeof(float) * num_target_ * config_.num_intention_point_cluster * 2, cudaMemcpyHostToDevice,
-    stream_));
+    copy_streams_()));
+
+  // Wait until all memory copy have been done
+  copy_streams_.SyncAllStreams();
 
   // DEBUG
   event_debugger_.createEvent(stream_);

--- a/src/mtr.cpp
+++ b/src/mtr.cpp
@@ -170,7 +170,7 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     copy_streams_()));
 
   // Wait until all memory copy have been done
-  copy_streams_.SyncAllStreams();
+  copy_streams_.syncAllStreams();
 
   // DEBUG
   event_debugger_.createEvent(stream_);


### PR DESCRIPTION
## Description
This PR accelerates top-k selection to solve the issue https://github.com/ktro2828/TensorRT-MTR/issues/18.
![elapsed_comparison](https://github.com/ktro2828/TensorRT-MTR/assets/3022416/4b5d1bd1-fc9a-48a9-b6b1-bda723213d6e)


## Tests performed

```shell
build/main onnx/mtr_dynamic.onnx --dynamic
```

## Effects on system behavior

Most modern GPUs have limitations for the shared memory size that can be assigned to one thread block; the upper limit is 48KB. The current implementation assigns a fixed number of items that can be handled by one CUDA thread, which the fixed number is calculated from the shared memory limitation. For this reason, if the value of `L` exceeds 256*24=6144, the function named `polylinePreprocessWithTopkLauncher` returns an invalid value error.